### PR TITLE
Bugfix/fix language selection

### DIFF
--- a/iframe/package.json
+++ b/iframe/package.json
@@ -9,7 +9,7 @@
       "serve": "vite preview"
     },
     "devDependencies": {
-      "vite": "^2.5.5"
+      "vite": "^2.5.4"
     },
     "dependencies": {
     }

--- a/iframe/package.json
+++ b/iframe/package.json
@@ -9,7 +9,7 @@
       "serve": "vite preview"
     },
     "devDependencies": {
-      "vite": "^2.5.4"
+      "vite": "^2.5.5"
     },
     "dependencies": {
     }

--- a/iframe/src/index.ts
+++ b/iframe/src/index.ts
@@ -50,8 +50,8 @@ function refreshTargetLanguage(lang: TranslateRequest['targetLanguage']) {
       .TranslateElement.getInstance()
       .B as typeof AvailableLanguages;
     const languageCode =
-      Object.keys(providedLanguages).find(
-        key => providedLanguages[key] === lang
+      Object.keys(AvailableLanguages).find(
+        key => AvailableLanguages[key] === lang
       ) as keyof typeof AvailableLanguages;
     const selected = languageSelectorElements()[
       Object.keys(providedLanguages).indexOf(languageCode)

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-translator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Translate text for free in the browser with iframe shenanigans",
   "main": "index.js",
   "repository": "https://github.com/KentoNishi/iframe-translator",


### PR DESCRIPTION
If the "lang" parameter for the "refreshTargetLanguage" method is the name of a language in English, e.g. "English"/"German", you need to search in the keys of your AvailableLanguages and not the  providedLanguages.

The providedLanguages are translated, resulting in a weird result, as you are now comparing if the "lang" ("German") is equal to some value of the dictionary {"de": "Deutsch", "en": "Englisch"}, which will result in an undefined result.

If you are comparing against your AvailableLanguages you will now search search against {"de": "German", "en": "English"}, which will result in a defined value. -> "de" for "German"